### PR TITLE
Update Read the Docs configuration to Python 3.10 and latest rocm-docs-core

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,4 +15,4 @@ python:
 build:
    os: ubuntu-22.04
    tools:
-      python: "3.8"
+      python: "3.10"

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,1 +1,1 @@
-rocm-docs-core>=0.30.3
+rocm-docs-core==1.4.0


### PR DESCRIPTION
Summary of proposed changes:

    ReadtheDocs will use Python 3.10 instead of Python 3.8 to build docs
        To use newer packages (eg: Sphinx 7)
    Doc builds will use latest rocm-docs-core version
