### PR TITLE
[AFLDSUP-83] Add missing header inclusion for C builds

### DIFF
--- a/include/rdc/rdc.h
+++ b/include/rdc/rdc.h
@@ -40,6 +40,7 @@ extern "C" {
 #include <cstdint>
 #else
 #include <assert.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 #endif  // __cplusplus


### PR DESCRIPTION
Addresses https://github.com/ROCm/ROCm/issues/5061