### PR TITLE
[AFLDSUP-87] Add libcap-dev to source build documentation dependency installation chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If you prefer to build RDC from source, follow the steps below.
 
     ```bash
     sudo apt-get update
-    sudo apt-get install automake make cmake g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl
+    sudo apt-get install automake make cmake g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl libcap-dev
     ```
 
 2. **Clone and Build gRPC:**

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -58,7 +58,7 @@ gRPC and Protoc must be built from source as the prebuilt packages are not avail
    .. code-block:: shell
 
     sudo apt-get update
-    sudo apt-get install automake make g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl
+    sudo apt-get install automake make g++ unzip build-essential autoconf libtool pkg-config libgflags-dev libgtest-dev clang libc++-dev curl libcap-dev
 
 2. Clone and build gRPC:
 


### PR DESCRIPTION
On Ubuntu Noble, ran into the following CMake error during configuration (source build):

```Package version: 1.1.1
The HASH value of the current HEAD submission in this RDC code repository is : 63f03ca
-- The C compiler identification is GNU 13.3.0
-- The CXX compiler identification is GNU 13.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMake Error at CMakeLists.txt:187 (find_library):
  Could not find LIB_CAP using the following names: cap```